### PR TITLE
Adjustments specific for survival

### DIFF
--- a/Survival/bukkit.yml
+++ b/Survival/bukkit.yml
@@ -30,7 +30,8 @@ spawn-limits:
   water-ambient: 6
   ambient: 1
 chunk-gc:
-  period-in-ticks: 400
+  period-in-ticks: 300
+  load-threshold: 300
 ticks-per:
   animal-spawns: 400
   monster-spawns: 10

--- a/Survival/paper.yml
+++ b/Survival/paper.yml
@@ -154,7 +154,7 @@ world-settings:
     allow-non-player-entities-on-scoreboards: false
     portal-search-radius: 128
     portal-create-radius: 16
-    container-update-tick-rate: 2
+    container-update-tick-rate: 3
     parrots-are-unaffected-by-player-movement: false
     disable-explosion-knockback: false
     prevent-tnt-from-moving-in-water: false

--- a/Survival/spigot.yml
+++ b/Survival/spigot.yml
@@ -85,7 +85,7 @@ world-settings:
     seed-slime: -1
     max-tnt-per-tick: 100
     mob-spawn-range: 2
-    view-distance: default
+    view-distance: 6
     enable-zombie-pigmen-portal-spawns: false
     item-despawn-rate: 3000
     arrow-despawn-rate: 200
@@ -96,8 +96,8 @@ world-settings:
     nerf-spawner-mobs: true
     max-entity-collisions: 2
     merge-radius:
-      exp: 4.0
-      item: 3.5
+      exp: 3
+      item: 2.5
     growth:
       cactus-modifier: 100
       cane-modifier: 100

--- a/Survival/spigot.yml
+++ b/Survival/spigot.yml
@@ -96,8 +96,8 @@ world-settings:
     nerf-spawner-mobs: true
     max-entity-collisions: 2
     merge-radius:
-      exp: 3
-      item: 2.5
+      exp: 6.0
+      item: 4.5
     growth:
       cactus-modifier: 100
       cane-modifier: 100


### PR DESCRIPTION
- Lowered the Chunk unloading tick count, introduced a loading threshold here too.

- Increased the container update tick rate by 1, any higher could bug the inventories/chests/shulkers/etc... of players

- Reduced the view-distance, so less chunks are sent to players, if this change impacts graphic quality of players, roll back

- Increased the merge-radius. I don't think this has any significant impact but... 

Any change *should* be rolled back if this causes significant impacts on the quality of gameplay. They are merely a suggestion that I think should work. Specific to Survival as I dont lag in creative!