### PR TITLE
Increased the View Distance

### DIFF
--- a/Survival/paper.yml
+++ b/Survival/paper.yml
@@ -261,7 +261,7 @@ world-settings:
       - stone
       - oak_planks
     viewdistances:
-      no-tick-view-distance: 6
+      no-tick-view-distance: 8
     squid-spawn-height:
       maximum: 0.0
     generator-settings:

--- a/Survival/spigot.yml
+++ b/Survival/spigot.yml
@@ -85,7 +85,7 @@ world-settings:
     seed-slime: -1
     max-tnt-per-tick: 100
     mob-spawn-range: 2
-    view-distance: 2
+    view-distance: default
     enable-zombie-pigmen-portal-spawns: false
     item-despawn-rate: 3000
     arrow-despawn-rate: 200


### PR DESCRIPTION
Now that the lag might be fixed, the viewing distance can be increased. For players with high performing devices, not all the chunks in the view horizon were being loaded, potentially leading to a bad game experience, although not a game-breaking one.

Changes made in paper.yml:
 - no-tick-view-distance was increased slightly to 8. Optimal results happen at 14 or 15, however for players with an unstable connection this could be a let down and with an unjustified increase in lag.

Changes made in spigot.yml:
 - view-distance was set to default, to let it be handled by server-properties or other component. This was the pre-lagfix setting, so it was readjusted to that.

Note: These are always possible to rollback if the game experience is worsen